### PR TITLE
feat: check PR title for conformance with Conventional Commits

### DIFF
--- a/.github/workflows/scan-pr-title.yml
+++ b/.github/workflows/scan-pr-title.yml
@@ -1,0 +1,35 @@
+name: Scan PR Title
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, edited, synchronize, reopened ]
+
+jobs:
+  check-pull-request-title:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          # Match pull request titles conventional commit syntax (https://www.conventionalcommits.org/en/v1.0.0/)
+          # (online tool for regex quick check: https://regex101.com/r/V5J8kh/1)
+          #
+          # Valid examples would be
+          # - fix: resolve minor issue
+          # - docs(Sample5): update docs for configuration
+          # - feat(management-api)!: change path to access contract agreements
+          #
+          # Invalid examples would be
+          # - Add cool feature
+          # - Feature/some cool improvement
+          # - fix: resolve minor issue.
+          # - fix: Resolve minor issue
+          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+((,|\/|\\)?\s?\w+)+\))?!?: [a-z][\S ]{1,80}[^\.]$'
+          allowed_prefixes: 'build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test'
+          prefix_case_sensitive: true
+          verbal_description: | 
+            The title must follow https://www.conventionalcommits.org/en/v1.0.0/. 
+            The colon must be followed by a lowercase letter. 
+            The title must not end with a period. 
+            Scopes (without space) and ! are allowed.


### PR DESCRIPTION
Relates https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/issues/21. Should be merged when merging eclipse-dataspace-protocol-base/.eclipsefdn/pull/8. 

We want a clean commit history on the main branch. This is a challenge with multiple people contributing, from multiple forks. We don't want to force people to stick to our rules until they open a PR.

When enforcing squash & merge with PR title as default, we can validate its conformance with Conventional Commits. As a result, we have a clean history on the main branch without people having to pay attention to the commit style within their forks. 

This action will take care of validation and mark the PR check as failed if the PR does not match the required format.