### PR TITLE
fix: change PR check to reusable workflow

### DIFF
--- a/.github/workflows/_pr-check.yml
+++ b/.github/workflows/_pr-check.yml
@@ -1,0 +1,10 @@
+name: Check Pull Request
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  trigger-workflow:
+    uses: eclipse-dataspace-protocol-base/.github/.github/workflows/scan-pr-title.yml@main

--- a/.github/workflows/scan-pr-title.yml
+++ b/.github/workflows/scan-pr-title.yml
@@ -1,9 +1,7 @@
 name: Scan PR Title
 
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ opened, edited, synchronize, reopened ]
+  workflow_call:
 
 jobs:
   check-pull-request-title:


### PR DESCRIPTION
Changes PR check to a reusable workflow. _Successfully tested in ISST fork._

Workflows in the `.github` repo are not automatically applied to all repos in the org. They must be explicitly called by a workflow in the repo.

Compare EDC config:
- https://github.com/eclipse-edc/Connector/blob/main/.github/workflows/scan-pull-request.yaml
- https://github.com/eclipse-edc/.github/blob/main/.github/workflows/scan-pull-request.yml